### PR TITLE
Change name docker image 'docker-phpnginx' to 'nginx-fpm'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fakereto/docker-phpnginx
+FROM fakereto/nginx-fpm
 COPY configs/app.conf ${NGINX_CONF_DIR}/sites-enabled/app.conf
 COPY entrypoint.sh /var/www/
 ENTRYPOINT ["/var/www/entrypoint.sh"]


### PR DESCRIPTION
Al tratar de correr con: `docker-compose up -d` no reconocía la imagen.

Revisando el dockerhub encontre que la imagen tiene un nombre diferente