### PR TITLE
Add php migrate commands to generate tables

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,6 +41,8 @@ _main() {
         composer update
     fi
     #php artisan migrate
+    php artisan migrate
+    php artisan db:seed
     exec "$@"
 }
 


### PR DESCRIPTION
La api me arrojaba un error 500 deciendo que no entcontraba la tabla api.users, me percate que al momento de levantar el docker no realizaba los comandos 'php artisan migrate' ni el 'php artisan db:seed'. Así que lo he añadido.